### PR TITLE
Fix duplicated text in docstring

### DIFF
--- a/hathi/__init__.py
+++ b/hathi/__init__.py
@@ -1,4 +1,4 @@
 """
-A SQL host scanner and dictionary attack tool. Comes with a script (`filter_pass.py`) to filter a series of password lists based on password strength.A SQL host scanner and dictionary attack tool. Comes with a script (`filter_pass.py`) to filter a series of password lists based on password strength.
+A SQL host scanner and dictionary attack tool. Comes with a script (`filter_pass.py`) to filter a series of password lists based on password strength.
 """
 __version__ = "1.1.0"


### PR DESCRIPTION
I noticed this is resulting in a duplicated description on the PyPI listing at https://pypi.org/project/hathi/

<img width="1135" alt="hathi_·_PyPI" src="https://user-images.githubusercontent.com/9599/133545203-f24bc8a5-09d0-4c6e-8b15-bd771d0db44f.png">
